### PR TITLE
Update php-cs-fixer --level option to --rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,9 @@ To install PHP Codesniffer (phpcs & phpcbf), follow the [recommended steps here]
   hooks:
   - id: php-cs-fixer
     files: \.(php)$
-    args: [--level=PSR2]
+    args: [--rules=@PSR2]
 ```
-Similar pattern as the php-cs hook. A bash script that will run the appropriate [PHP Coding Standards Fixer](http://cs.sensiolabs.org/) executable and to fix errors according to the configuration. It accepts all of the args from the `php-cs-fixer` command, in particular the `--level`, `--config`, and `--config-file` options.
+Similar pattern as the php-cs hook. A bash script that will run the appropriate [PHP Coding Standards Fixer](https://cs.symfony.com/) executable and to fix errors according to the configuration. It accepts all of the args from the `php-cs-fixer` command, in particular the `--rules`, `--config`, and `--config-file` options.
 
 The tool will fail a build when it has made changes to the staged files. This allows a developer to do a `git diff` and examine the changes that it has made. Remember that you may omit this if needed with a `SKIP=php-cs-fixer git commit`.
 


### PR DESCRIPTION
When I tried using the `php-cs-fixer` hook for the first time, I got the following error:
`The "--level" option does not exist.`

PHP CS Fixer's `fix` method args were changed in version 2.0 in 2015 in commit https://github.com/FriendsOfPHP/PHP-CS-Fixer/commit/d1aec7bc12918281f370b4a58533aa30fc147004.
Specifically, the `--level` arg was deprecated and changed to `--rules`, with the requirement of an @ symbol to indicate a pre-defined ruleset.

Update the example args to user the new syntax, so the hook works for PHP CS Fixer versions 2.0 and up.